### PR TITLE
Add translation to template name in autoresponder

### DIFF
--- a/mass_mailing_autoresponder/__manifest__.py
+++ b/mass_mailing_autoresponder/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Mail Autoresponder',
     'summary': "Adds an automatic Emailing Trigger based service",
-    'version': '12.0.2.0.0',
+    'version': '12.0.2.1.1',
     'author': 'Vertel AB',
     'license': 'AGPL-3',
     'maintainer': 'Vertel AB',
@@ -17,6 +17,7 @@
         V12.0.1.0.9  Updates on sending logic \n
         V12.0.2.0.0  Changed access right for autoresponder menu \n
         v12.0.2.1.0  Added translation to mass_mailing_autoresponder \n 
+        v12.0.2.1.1  Add translation to template name in autoresponder \n
     """,
     'depends': [
         'base_setup', 'mail', 'mass_mailing',

--- a/mass_mailing_autoresponder/data/mail_template.xml
+++ b/mass_mailing_autoresponder/data/mail_template.xml
@@ -1,7 +1,7 @@
 <odoo>
     <data>
         <record id="on_boarding_email_template" model="mail.template">
-            <field name="name">Welcome to our agency</field>
+            <field name="name">Välkommen till oss</field>
             <field name="model_id" ref="mass_mailing_autoresponder.model_partner_event"/>
             <field name="subject">Welcome to us</field>
             <field name="email_to">${ctx['partner_email'] | safe}</field>
@@ -20,7 +20,7 @@
         </record>
 
         <record id="meeting_invitation_email_template" model="mail.template">
-            <field name="name">Meeting Invitation</field>
+            <field name="name">Mötesinbjudan</field>
             <field name="model_id" ref="mass_mailing_autoresponder.model_partner_event"/>
             <field name="subject">Meeting Invitation</field>
             <field name="email_to">${ctx['partner_email'] | safe}</field>
@@ -39,7 +39,7 @@
         </record>
 
         <record id="meeting_reminder_email_template" model="mail.template">
-            <field name="name">Reminder of the Meeting</field>
+            <field name="name">Påminnelse om mötet</field>
             <field name="model_id" ref="mass_mailing_autoresponder.model_partner_event"/>
             <field name="subject">Reminder of the Meeting</field>
             <field name="email_to">${ctx['partner_email'] | safe}</field>
@@ -59,7 +59,7 @@
 
 
         <record id="meeting_follow_up_email_template" model="mail.template">
-            <field name="name">Follow Up of the Meeting</field>
+            <field name="name">Uppföljning av mötet</field>
             <field name="model_id" ref="mass_mailing_autoresponder.model_partner_event"/>
             <field name="subject">Follow Up of the Meeting</field>
             <field name="email_to">${ctx['partner_email'] | safe}</field>


### PR DESCRIPTION
The four template names in autoresponder have now been translated into Swedish.