### PR TITLE
AFC-3042-wrongly-displayed-statistics

### DIFF
--- a/mass_mailing_statistics_af/__manifest__.py
+++ b/mass_mailing_statistics_af/__manifest__.py
@@ -1,11 +1,12 @@
 {
     "name": "Mass mailing statistics AF",
     "summary": "This module will show number for Email tracking events in Mass Mailing.",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "Email Marketing",
     "description": """
 	 v12.0.0.1 AFC-2100  Added numbers for email tracking events in Mass mailing kanban and form view.\n
 	 v12.1.0.0 AFC-2867  Added fields in mass mailing list view.\n
+	 v12.1.0.1 AFC-3042  Fixed the total click calulation
     """,
     "license": "AGPL-3",
     "maintainer": "Vertel AB",

--- a/mass_mailing_statistics_af/models/mass_mailing.py
+++ b/mass_mailing_statistics_af/models/mass_mailing.py
@@ -42,7 +42,6 @@ class MassMailing(models.Model):
             row['opened_ratio'] = 100.0 * row['opened'] / total
             row['opened'] = row['opened']
             row['clicks_ratio'] = 100.0 * row['clicked'] / total
-            #row['clicks'] = 100.0 * row['clicked'] / total
             row['clicks'] = row['clicked']
             row['replied_ratio'] = 100.0 * row['replied'] / total
             row['replied'] = row['replied']

--- a/mass_mailing_statistics_af/models/mass_mailing.py
+++ b/mass_mailing_statistics_af/models/mass_mailing.py
@@ -42,7 +42,8 @@ class MassMailing(models.Model):
             row['opened_ratio'] = 100.0 * row['opened'] / total
             row['opened'] = row['opened']
             row['clicks_ratio'] = 100.0 * row['clicked'] / total
-            row['clicks'] = 100.0 * row['clicked'] / total
+            #row['clicks'] = 100.0 * row['clicked'] / total
+            row['clicks'] = row['clicked']
             row['replied_ratio'] = 100.0 * row['replied'] / total
             row['replied'] = row['replied']
             row['bounced_ratio'] = 100.0 * row['bounced'] / total


### PR DESCRIPTION
* Fixed the way we display clicks in mass_mailing_statistics.